### PR TITLE
Change curl bin detection to be valid cross-platform

### DIFF
--- a/packages/ExtensionStore/github_scrubber.js
+++ b/packages/ExtensionStore/github_scrubber.js
@@ -1280,7 +1280,7 @@ CURL.prototype.get = function (command, wait) {
     var bin = this.bin;
 
     // The toonboom bundled curl doesn't seem to be equiped for ssh so we have to use unsafe mode
-    if (bin.indexOf("ToonBoom") != -1) command = ["-k"].concat(command)
+    if (bin.indexOf("bin_3rdParty") != -1) command = ["-k"].concat(command)
 
     this.log.debug("starting process :" + bin + " " + command.join(" "));
     p.start(bin, command);


### PR DESCRIPTION
The existing approach for detecting when using the included Harmony curl binary doesn't work on Windows, where paths are "Toon Boom". The revised string should be valid on all platforms.